### PR TITLE
feat: 작품 전체 조회(페이지네이션) 및 상세 조회 기능 구현

### DIFF
--- a/src/common/dto/page-req.dto.ts
+++ b/src/common/dto/page-req.dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PageReqDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page: number = 1;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  limit: number = 10;
+}

--- a/src/modules/works/works.controller.ts
+++ b/src/modules/works/works.controller.ts
@@ -1,11 +1,14 @@
 import {
   Body,
   Controller,
+  Get,
   Post,
+  Query,
   Req,
   UploadedFile,
   UseGuards,
   UseInterceptors,
+  ValidationPipe,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -14,6 +17,7 @@ import { WorksService } from './works.service';
 import { CreateWorkDto } from './dto/create-work.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { SellerVerifiedGuard } from '../../common/guards/seller-verified.guard';
+import { PageReqDto } from '../../common/dto/page-req.dto';
 
 @Controller('works')
 export class WorksController {
@@ -34,6 +38,8 @@ export class WorksController {
       }),
     }),
   )
+
+  //작품 생성
   async create(
     @Req() req: any,
     @UploadedFile() file: Express.Multer.File,
@@ -47,5 +53,12 @@ export class WorksController {
       ...createWorkDto,
       image_url: imageUrl,
     });
+  }
+
+  @Get()
+  findAllPublic(
+    @Query(new ValidationPipe({ transform: true })) query: PageReqDto,
+  ) {
+    return this.worksService.findAllPublic(query);
   }
 }


### PR DESCRIPTION
- 작품(Works) 도메인의 조회 API(findAllPublic)를 구현

- 대량의 데이터 조회 시 성능 저하를 방지하기 위해 페이지네이션(Pagination)을 적용

- 작성자 정보 조회 시 불필요한 민감 정보(비밀번호 등)가 노출되지 않도록 Response 데이터를 최적화

- #1 